### PR TITLE
Types converted to use stdint.h types.

### DIFF
--- a/RX.h
+++ b/RX.h
@@ -2,7 +2,7 @@
  * OpenLRSng receiver code
  ****************************************************/
 
-volatile unsigned char RF_Mode = 0;
+volatile uint8_t RF_Mode = 0;
 
 #define Available 0
 #define Transmit 1
@@ -10,25 +10,25 @@ volatile unsigned char RF_Mode = 0;
 #define Receive 3
 #define Received 4
 
-unsigned char RF_channel = 0;
+uint8_t RF_channel = 0;
 
-unsigned long time;
-unsigned long last_pack_time = 0;
-unsigned long last_rssi_time = 0;
-unsigned long fs_time; // time when failsafe activated
+uint32_t time;
+uint32_t last_pack_time = 0;
+uint32_t last_rssi_time = 0;
+uint32_t fs_time; // time when failsafe activated
 
-unsigned long last_beacon;
+uint32_t last_beacon;
 
-unsigned char  RSSI_count = 0;
-unsigned short RSSI_sum = 0;
+uint8_t  RSSI_count = 0;
+uint16_t RSSI_sum = 0;
 
-int ppmCountter = 0;
-int ppmTotal = 0;
+int16_t ppmCountter = 0;
+int16_t ppmTotal = 0;
 
 boolean PWM_output = 1; // set if parallel PWM output is desired
 
-short firstpack = 0;
-short lostpack = 0;
+int16_t firstpack = 0;
+int16_t lostpack = 0;
 
 boolean willhop = 0,fs_saved = 0;
 
@@ -54,7 +54,7 @@ ISR(TIMER1_OVF_vect) {
       PORTD &= ~PWM_MASK_PORTD(PWM_ALL_MASK);
     }
   } else {
-    unsigned short ppmOut = servoBits2Us(PPM[ppmCountter]) * 2;
+    int16_t  ppmOut = servoBits2Us(PPM[ppmCountter]) * 2;
     ppmTotal += ppmOut;
     ICR1 = ppmOut;
     if (PWM_output) {
@@ -111,8 +111,8 @@ void save_failsafe_values(void){
 
 void load_failsafe_values(void){
 
-  unsigned char ee_buf[10];
-  for (int i=0; i<10; i++) {
+  uint8_t ee_buf[10];
+  for (int16_t i=0; i<10; i++) {
     ee_buf[i]=EEPROM.read(FAILSAFE_OFFSET+i);
   }
   PPM[0]= ee_buf[0] + ((ee_buf[4] & 0x03) << 8);
@@ -125,19 +125,19 @@ void load_failsafe_values(void){
   PPM[7]= ee_buf[8] + ((ee_buf[9] & 0xc0) << 2);
 }
 
-int bindReceive(unsigned long timeout) {
-  unsigned long start = millis();
+int16_t bindReceive(uint32_t timeout) {
+  uint32_t start = millis();
   init_rfm(1);
   RF_Mode = Receive;
   to_rx_mode();
   Serial.println("Waiting bind\n");
   while ((!timeout) || ((millis() - start) < timeout)) {
-    if(RF_Mode == Received) {  // RFM22B INT pin Enabled by received Data
+    if(RF_Mode == Received) {  // RFM22B int16_t pin Enabled by received Data
       Serial.println("Got pkt\n");
       RF_Mode=Receive;
       spiSendAddress(0x7f); // Send the package read command
-      for (unsigned char i=0; i < sizeof(bind_data); i++) {
-        *(((unsigned char*)&bind_data)+i) = spiReadData();
+      for (uint8_t i=0; i < sizeof(bind_data); i++) {
+        *(((uint8_t*)&bind_data)+i) = spiReadData();
       }
       if (bind_data.version == BINDING_VERSION) {
         Serial.println("data good\n");
@@ -150,8 +150,8 @@ int bindReceive(unsigned long timeout) {
   return 0;
 }
 
-int checkJumpper(unsigned char pin1,unsigned char pin2) {
-  int ret=0;
+int16_t checkJumpper(uint8_t pin1,uint8_t pin2) {
+  int16_t ret=0;
   pinMode(pin1,OUTPUT);
   digitalWrite(pin1, 1);
   digitalWrite(pin2, 1); // enable pullup
@@ -235,7 +235,7 @@ void setup() {
 
 //############ MAIN LOOP ##############
 void loop() {
-  unsigned long time;
+  uint32_t time;
   if (spiReadRegister(0x0C)==0) { // detect the locked module and reboot
     Serial.println("RX hang");
     init_rfm(0);
@@ -244,7 +244,7 @@ void loop() {
 
   time = micros();
   
-  if(RF_Mode == Received) {  // RFM22B INT pin Enabled by received Data
+  if(RF_Mode == Received) {  // RFM22B int16_t pin Enabled by received Data
 
     RF_Mode = Receive;
 
@@ -258,7 +258,7 @@ void loop() {
 
     spiSendAddress(0x7f); // Send the package read command
 
-    for (int i=0; i<11; i++) {
+    for (int16_t i=0; i<11; i++) {
       rx_buf[i] = spiReadData();
     }
 

--- a/TX.h
+++ b/TX.h
@@ -1,18 +1,18 @@
 /****************************************************
  * OpenLRSng transmitter code
  ****************************************************/
-unsigned char RF_channel = 0;
+uint8_t RF_channel = 0;
 
-unsigned char FSstate = 0; // 1 = waiting timer, 2 = send FS, 3 sent waiting btn release
-unsigned long FStime = 0;  // time when button went down...
+uint8_t FSstate = 0; // 1 = waiting timer, 2 = send FS, 3 sent waiting btn release
+uint32_t FStime = 0;  // time when button went down...
 
-unsigned long lastSent = 0;
+uint32_t lastSent = 0;
 
-volatile unsigned char ppmAge = 0; // age of PPM data
+volatile uint8_t ppmAge = 0; // age of PPM data
 
 
-volatile unsigned int startPulse = 0;
-volatile byte         ppmCounter = PPM_CHANNELS; // ignore data until first sync pulse
+volatile uint16_t startPulse = 0;
+volatile uint8_t  ppmCounter = PPM_CHANNELS; // ignore data until first sync pulse
 
 #define TIMER1_FREQUENCY_HZ 50
 #define TIMER1_PRESCALER    8
@@ -23,10 +23,10 @@ volatile byte         ppmCounter = PPM_CHANNELS; // ignore data until first sync
  * Interrupt Vector
  ****************************************************/
 ISR(TIMER1_CAPT_vect) {
-  unsigned int stopPulse = ICR1;
+  uint16_t stopPulse = ICR1;
 
   // Compensate for timer overflow if needed
-  unsigned int pulseWidth = ((startPulse > stopPulse) ? TIMER1_PERIOD : 0) + stopPulse - startPulse;
+  uint16_t pulseWidth = ((startPulse > stopPulse) ? TIMER1_PERIOD : 0) + stopPulse - startPulse;
 
   if (pulseWidth > 5000) {      // Verify if this is the sync pulse (2.5ms)
     ppmCounter = 0;             // -> restart the channel counter
@@ -51,7 +51,7 @@ void setupPPMinput() {
 #else // sample PPM using pinchange interrupt
 ISR(PPM_Signal_Interrupt){
 
-  unsigned int time_temp;
+  uint16_t time_temp;
 
   if (PPM_Signal_Edge_Check) {// Only works with rising edge of the signal
     time_temp = TCNT1; // read the timer1 value
@@ -80,13 +80,13 @@ void setupPPMinput() {
 
 void scannerMode(){
   char c;
-  unsigned long nextConfig[4] = {0,0,0,0};
-  unsigned long startFreq=430000000, endFreq=440000000, nrSamples=500, stepSize=50000;
-  unsigned long currentFrequency = startFreq;
-  unsigned long currentSamples = 0;
-  unsigned char nextIndex=0;
-  unsigned char rssiMin=0, rssiMax=0;
-  unsigned long rssiSum=0;
+  uint32_t nextConfig[4] = {0,0,0,0};
+  uint32_t startFreq=430000000, endFreq=440000000, nrSamples=500, stepSize=50000;
+  uint32_t currentFrequency = startFreq;
+  uint32_t currentSamples = 0;
+  uint8_t nextIndex=0;
+  uint8_t rssiMin=0, rssiMax=0;
+  uint32_t rssiSum=0;
   Red_LED_OFF;
   Green_LED_OFF;
   digitalWrite(BUZZER, LOW);
@@ -147,7 +147,7 @@ void scannerMode(){
       delay(1);
     }
     if (currentSamples < nrSamples) {
-      unsigned char val = rfmGetRSSI();
+      uint8_t val = rfmGetRSSI();
       rssiSum+=val;
       if (val>rssiMax) rssiMax=val;
       if (val<rssiMin) rssiMin=val;
@@ -182,7 +182,7 @@ void handleCLI(char c) {
 }
 
 void bindMode() {
-  unsigned long prevsend = millis();
+  uint32_t prevsend = millis();
   init_rfm(1);
   while (Serial.available()) Serial.read(); // flush serial
   while(1) {
@@ -190,7 +190,7 @@ void bindMode() {
       prevsend=millis();
       Green_LED_ON;
       digitalWrite(BUZZER, HIGH); // Buzzer on
-      tx_packet((unsigned char*)&bind_data, sizeof(bind_data));
+      tx_packet((uint8_t*)&bind_data, sizeof(bind_data));
       Green_LED_OFF;
       digitalWrite(BUZZER, LOW); // Buzzer off
     }
@@ -200,7 +200,7 @@ void bindMode() {
 
 void checkButton(){
   
-  unsigned long time,loop_time;
+  uint32_t time,loop_time;
 
   if (digitalRead(BTN)==0) // Check the button
     {
@@ -217,7 +217,7 @@ void checkButton(){
 
     // Check the button again, If it is still down reinitialize
     if (0 == digitalRead(BTN)) {
-      int bzstate=HIGH;
+      int16_t bzstate=HIGH;
       digitalWrite(BUZZER,bzstate);
       loop_time = millis();
       while (0 == digitalRead(BTN)) { // wait for button to release
@@ -330,12 +330,12 @@ void loop() {
     Red_LED_OFF;
   }
 
-  unsigned long time = micros();
+  uint32_t time = micros();
 
   if ((time - lastSent) >= modem_params[bind_data.modem_params].interval) {
     lastSent = time;
     if (ppmAge < 8) {
-      unsigned char tx_buf[11];
+      uint8_t tx_buf[11];
       ppmAge++;
 
       // Construct packet to be sent

--- a/binding.h
+++ b/binding.h
@@ -6,27 +6,27 @@
 
 #define EEPROM_OFFSET     0x00
 
-unsigned char bind_magic[4] = {0xDE,0xC1,0xBE,0x15};
-static unsigned char default_hop_list[] = {DEFAULT_HOPLIST};
+uint8_t bind_magic[4] = {0xDE,0xC1,0xBE,0x15};
+static uint8_t default_hop_list[] = {DEFAULT_HOPLIST};
 
 struct bind_data {
-  unsigned char version;
-  unsigned long rf_frequency;
-  unsigned char rf_magic[4];
-  unsigned char rf_power;
-  unsigned char hopcount;
-  unsigned char hopchannel[8]; // max 8 channels
-  unsigned char rc_channels; //normally 8
-  unsigned char modem_params; 
-  unsigned long beacon_frequency;
-  unsigned char beacon_interval;
-  unsigned char beacon_deadtime;
+  uint8_t version;
+  uint32_t rf_frequency;
+  uint8_t rf_magic[4];
+  uint8_t rf_power;
+  uint8_t hopcount;
+  uint8_t hopchannel[8]; // max 8 channels
+  uint8_t rc_channels; //normally 8
+  uint8_t modem_params; 
+  uint32_t beacon_frequency;
+  uint8_t beacon_interval;
+  uint8_t beacon_deadtime;
 } bind_data;
 
 struct rfm22_modem_regs {
-  unsigned long bps;
-  unsigned long interval;
-  unsigned char r_1c, r_1d, r_1e, r_20, r_21, r_22, r_23, r_24, r_25, r_2a, r_6e, r_6f;
+  uint32_t bps;
+  uint32_t interval;
+  uint8_t r_1c, r_1d, r_1e, r_20, r_21, r_22, r_23, r_24, r_25, r_2a, r_6e, r_6f;
 } modem_params[3] = {
   { 4800,  50000, 0x1a, 0x40, 0x0a, 0xa1, 0x20, 0x4e, 0xa5, 0x00, 0x1b, 0x1e, 0x27, 0x52 },
   { 9600,  25000, 0x05, 0x40, 0x0a, 0xa1, 0x20, 0x4e, 0xa5, 0x00, 0x20, 0x24, 0x4e, 0xa5 },
@@ -36,14 +36,14 @@ struct rfm22_modem_regs {
 struct rfm22_modem_regs bind_params =
   { 9600,  25000, 0x05, 0x40, 0x0a, 0xa1, 0x20, 0x4e, 0xa5, 0x00, 0x20, 0x24, 0x4e, 0xa5 };
 
-int bindReadEeprom() {
-  for (unsigned char i=0; i<4; i++) {
+int16_t bindReadEeprom() {
+  for (uint8_t i=0; i<4; i++) {
     if (EEPROM.read(EEPROM_OFFSET+i) != bind_magic[i]) {
       return 0; // Fail
     }
   }
-  for (unsigned char i=0; i<sizeof(bind_data); i++) {
-    *((unsigned char *)&bind_data + i) = EEPROM.read(EEPROM_OFFSET+4+i); 
+  for (uint8_t i=0; i<sizeof(bind_data); i++) {
+    *((uint8_t *)&bind_data + i) = EEPROM.read(EEPROM_OFFSET+4+i); 
   }
   if (bind_data.version != BINDING_VERSION) {
     return 0;
@@ -52,12 +52,12 @@ int bindReadEeprom() {
 }
 
 void bindWriteEeprom() {
-  for (unsigned char i=0; i<4; i++) {
+  for (uint8_t i=0; i<4; i++) {
     EEPROM.write(EEPROM_OFFSET+i, bind_magic[i]);
   }
 
-  for (unsigned char i=0; i<sizeof(bind_data); i++) {
-    EEPROM.write(EEPROM_OFFSET+4+i, *((unsigned char *)&bind_data + i)); 
+  for (uint8_t i=0; i<sizeof(bind_data); i++) {
+    EEPROM.write(EEPROM_OFFSET+4+i, *((uint8_t *)&bind_data + i)); 
   }
 }
 
@@ -65,11 +65,11 @@ void bindInitDefaults() {
   bind_data.version = BINDING_VERSION;
   bind_data.rf_power = DEFAULT_RF_POWER;
   bind_data.rf_frequency = DEFAULT_CARRIER_FREQUENCY;
-  for (unsigned char c=0; c<4; c++) {
+  for (uint8_t c=0; c<4; c++) {
     bind_data.rf_magic[c] = default_rf_magic[c];
   }
   bind_data.hopcount = sizeof(default_hop_list)/sizeof(default_hop_list[0]);
-  for (unsigned char c=0; c<8; c++) {
+  for (uint8_t c=0; c<8; c++) {
     bind_data.hopchannel[c] = (c<bind_data.hopcount) ? default_hop_list[c] : 0;
   }
   bind_data.rc_channels = 8;
@@ -86,15 +86,15 @@ void bindInitDefaults() {
 } 
 
 void bindRandomize() {
-  for (unsigned char c=0; c<4; c++) {
+  for (uint8_t c=0; c<4; c++) {
     bind_data.rf_magic[c] = random(255);
   }
   bind_data.hopcount=6;
-  for (unsigned char c=0; c<bind_data.hopcount; c++) {
+  for (uint8_t c=0; c<bind_data.hopcount; c++) {
     again:
-    unsigned char ch = random(50);
+    uint8_t ch = random(50);
     // don't allow same channel twice
-    for (unsigned char i=0;i<c;i++) {
+    for (uint8_t i=0;i<c;i++) {
       if (bind_data.hopchannel[i] == ch) goto again;
     }
     bind_data.hopchannel[c] = ch;
@@ -115,7 +115,7 @@ void bindPrint() {
   Serial.print("4) Number of hops: ");
   Serial.println(bind_data.hopcount);
   Serial.print("5) Hop channels:   ");
-  for (unsigned char c = 0; c<bind_data.hopcount; c++) {
+  for (uint8_t c = 0; c<bind_data.hopcount; c++) {
     Serial.print(bind_data.hopchannel[c],16); // max 8 channels
     if (c+1 != bind_data.hopcount) {
       Serial.print(":");

--- a/hardware.h
+++ b/hardware.h
@@ -181,7 +181,7 @@
     #define PWM_8 12
     #define PWM_8_MASK 0x1000 // PB4
 
-    const unsigned short PWM_MASK[8] = { PWM_1_MASK, PWM_2_MASK, PWM_3_MASK, PWM_4_MASK, PWM_5_MASK, PWM_6_MASK, PWM_7_MASK, PWM_8_MASK };
+    const uint16_t PWM_MASK[8] = { PWM_1_MASK, PWM_2_MASK, PWM_3_MASK, PWM_4_MASK, PWM_5_MASK, PWM_6_MASK, PWM_7_MASK, PWM_8_MASK };
     #define PWM_ALL_MASK 0x1FE0 // all bits used for PWM (logic OR of above)
 
     #define PWM_MASK_PORTB(x) (((x)>>8) & 0xff)

--- a/openLRSng.ino
+++ b/openLRSng.ino
@@ -76,7 +76,7 @@
 //###### RF DEVICE ID HEADER #######
 // Change this 4 byte values for isolating your transmission,
 // RF module accepts only data with same header
-static unsigned char default_rf_magic[4] = {'@','K','H','a'};
+static uint8_t default_rf_magic[4] = {'@','K','H','a'};
 
 // RF Data Rate --- choose wisely between range vs. performance
 //  0 -- 4800bps, best range, 20Hz update rate


### PR DESCRIPTION
Performed comparisons of the hex file before and after the changes and the resulting hex was identical for both the rx and tx code.

There were two exceptions to this.  When the local fb inside 'rfmSetCarrierFrequency' and 'beacon_send' were converted to uint16_t from 'unsigned short' there was an unexplained difference in the resulting binary. Suspect some sort of type promotion by the compiler.

fb was left typed as 'unsigned short' in both cases until the cause of the difference is investigated.
