### PR TITLE
Add the DEBUG and ANALYSER control parameters

### DIFF
--- a/TX.h
+++ b/TX.h
@@ -86,6 +86,7 @@ void setupPPMinput(void)
 }
 #endif
 
+#ifdef DEBUG
 void handleCLI(char c)
 {
   switch (c) {
@@ -93,21 +94,26 @@ void handleCLI(char c)
     bindPrint();
     break;
 
+#ifdef ANALYSER
   case '#':
     buzzerOff();
     scannerMode();
     break;
+#endif
   }
 }
+#endif
 
 void bindMode(void)
 {
   uint32_t prevsend = millis();
   init_rfm(1);
 
+#ifdef DEBUG
   while (Serial.available()) {
     Serial.read();    // flush serial
   }
+#endif
 
   while (1) {
     if (millis() - prevsend > 200) {
@@ -119,9 +125,11 @@ void bindMode(void)
       buzzerOff();
     }
 
+#ifdef DEBUG
     while (Serial.available()) {
       handleCLI(Serial.read());
     }
+#endif
   }
 }
 
@@ -170,11 +178,15 @@ void checkButton(void)
         bindRandomize();
       }
       bindWriteEeprom();
+#ifdef DEBUG
       bindPrint();
+#endif
     }
 
     // Enter binding mode, automatically after recoding or when pressed for shorter time.
+#ifdef DEBUG
     Serial.println("Entering binding mode\n");
+#endif
     bindMode();
   }
 }
@@ -238,15 +250,23 @@ void setup(void)
 
   buzzerInit();
 
+#if defined(DEBUG) || defined(ANALYSER)
   Serial.begin(SERIAL_BAUD_RATE);
+#endif
 
   if (bindReadEeprom()) {
+#ifdef DEBUG
     Serial.print("Loaded settings from EEPROM\n");
+#endif
   } else {
+#ifdef DEBUG
     Serial.print("EEPROM data not valid, reiniting\n");
+#endif
     bindInitDefaults();
     bindWriteEeprom();
+#ifdef DEBUG
     Serial.print("EEPROM data saved\n");
+#endif
   }
 
   setupPPMinput();
@@ -277,7 +297,9 @@ void loop(void)
 {
 
   if (spiReadRegister(0x0C) == 0) {     // detect the locked module and reboot
+#ifdef DEBUG
     Serial.println("module locked?");
+#endif
     Red_LED_ON;
     init_rfm(0);
     rx_reset();

--- a/binding.h
+++ b/binding.h
@@ -117,6 +117,7 @@ again:
   }
 }
 
+#ifdef DEBUG
 void bindPrint(void)
 {
 
@@ -153,5 +154,4 @@ void bindPrint(void)
   Serial.print("9) Beacon Deadtime:");
   Serial.println(bind_data.beacon_deadtime);
 }
-
-
+#endif

--- a/common.h
+++ b/common.h
@@ -60,6 +60,7 @@ uint16_t servoBits2Us(uint16_t x)
   return ret;
 }
 
+#ifdef ANALYSER
 // Spectrum analyser 'submode'
 void scannerMode(void)
 {
@@ -174,6 +175,7 @@ void scannerMode(void)
 
   //never exit!!
 }
+#endif
 
 
 void RFM22B_Int()

--- a/openLRSng.ino
+++ b/openLRSng.ino
@@ -35,6 +35,14 @@
 //### CONFIGURATION SECTION ###
 //#############################
 
+//####### SERIAL DEBUG #######
+// Enable the TTL serial line for debug propouses
+#define DEBUG
+
+//####### SPECTRUM ANALYSER #######
+// Enable spectrum analyser functionality on the firmware
+#define ANALYSER
+
 //####### COMPILATION TARGET #######
 // Enable to compile transmitter code, default is RX
 #define COMPILE_TX
@@ -51,7 +59,8 @@
 // 3 = OpenLRS Rx v2 Board or OrangeRx UHF RX
 #define RX_BOARD_TYPE 3
 
-//###### SERIAL PORT SPEED - just debugging atm. #######
+//###### SERIAL PORT SPEED #######
+// This baud rate will *only* be used if DEBUG is defined
 #define SERIAL_BAUD_RATE 115200 //115.200 baud serial port speed
 
 //###### Should receiver always bind on bootup for 0.5s ######


### PR DESCRIPTION
Add the option to control if DEBUG information is sent to the serial
line; add the option to control if the spectrum ANALYSER is enabled on
the firmware. The control of these parameters allows size savings up to
~39%.

TX Original: 9.458 bytes
TX with DEBUG: 8.368 bytes
TX with ANALYSER: 7.018 bytes
TX without DEBUG and ANAYLSER: 5.808 bytes
Total saving is ~39% with both options disabled

RX Original: 10.446 bytes
RX with DEBUG: 9.378 bytes
RX with ANALYSER: 9.938 bytes
RX without DEBUG AND ANALYSER: 7.270 bytes
Total saving is ~30% with both options disabled
