### PR TITLE
Add EditorConfig configuration

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[Makefile]
+indent_size = 4
+indent_style = tab


### PR DESCRIPTION
EditorConfig is a cross plattform/editor plugin to help enforce a
coherent coding style (i.e. line endings, no trailing whitespace,
indentation etc) and supports a load of editors/ides.
See http://editorconfig.org/#download for your the plugins.

For now I set the encoding to utf-8, linux style line endings,
indentation of 2 spaces, insertion of final newline and enabled the
trimming of trailing whitespace.
