### PR TITLE
optional link-state CSV debugging feature

### DIFF
--- a/RX.h
+++ b/RX.h
@@ -632,6 +632,11 @@ void setup()
     }
   }
 
+  if (checkIfConnected(OUTPUT_PIN[1], OUTPUT_PIN[2])){
+	 Serial.println("dumping CSV stats");
+    linkDump=1;
+  }
+  
   if (checkIfConnected(OUTPUT_PIN[0], OUTPUT_PIN[1]) || (!bindReadEeprom())) {
     Serial.print("EEPROM data not valid or bind jumpper set, forcing bind\n");
 
@@ -659,9 +664,6 @@ void setup()
     }
   }
 
-  if (checkIfConnected(OUTPUT_PIN[1], OUTPUT_PIN[2])){
-    linkDump=1;
-  }
   
   if ((rx_config.pinMapping[SDA_OUTPUT] == PINMAP_SDA) &&
       (rx_config.pinMapping[SCL_OUTPUT] == PINMAP_SCL)) {

--- a/TX.h
+++ b/TX.h
@@ -547,7 +547,7 @@ static inline void processSBUS(uint8_t c)
         PPM[(set<<3)+6] = (((ppmWork.sbus.ch[set].ch6 >> 1) * 5) >> 2);
         PPM[(set<<3)+7] = (((ppmWork.sbus.ch[set].ch7 >> 1) * 5) >> 2);
       }
-      for(int i=0;i<16;i++){
+      for(uint8_t i=0; i<16; i++){
        PPM[i]=(PPM[i]<=108)?0:(PPM[i]-108);
      }	  
       if ((ppmWork.sbus.status & 0x08)==0) {

--- a/TX.h
+++ b/TX.h
@@ -538,15 +538,18 @@ static inline void processSBUS(uint8_t c)
     if ((frameIndex == 23) && (c == SBUS_TAIL)) {
       uint8_t set;
       for (set = 0; set < 2; set++) {
-        PPM[(set<<3)] = ppmWork.sbus.ch[set].ch0 >> 1;
-        PPM[(set<<3)+1] = ppmWork.sbus.ch[set].ch1 >> 1;
-        PPM[(set<<3)+2] = ppmWork.sbus.ch[set].ch2 >> 1;
-        PPM[(set<<3)+3] = ppmWork.sbus.ch[set].ch3 >> 1;
-        PPM[(set<<3)+4] = ppmWork.sbus.ch[set].ch4 >> 1;
-        PPM[(set<<3)+5] = ppmWork.sbus.ch[set].ch5 >> 1;
-        PPM[(set<<3)+6] = ppmWork.sbus.ch[set].ch6 >> 1;
-        PPM[(set<<3)+7] = ppmWork.sbus.ch[set].ch7 >> 1;
+        PPM[(set<<3)] = (((ppmWork.sbus.ch[set].ch0 >> 1) * 5) >> 2);
+        PPM[(set<<3)+1] = (((ppmWork.sbus.ch[set].ch1 >> 1) * 5) >> 2);
+        PPM[(set<<3)+2] = (((ppmWork.sbus.ch[set].ch2 >> 1) * 5) >> 2);
+        PPM[(set<<3)+3] = (((ppmWork.sbus.ch[set].ch3 >> 1) * 5) >> 2);
+        PPM[(set<<3)+4] = (((ppmWork.sbus.ch[set].ch4 >> 1) * 5) >> 2);
+        PPM[(set<<3)+5] = (((ppmWork.sbus.ch[set].ch5 >> 1) * 5) >> 2);
+        PPM[(set<<3)+6] = (((ppmWork.sbus.ch[set].ch6 >> 1) * 5) >> 2);
+        PPM[(set<<3)+7] = (((ppmWork.sbus.ch[set].ch7 >> 1) * 5) >> 2);
       }
+      for(int i=0;i<16;i++){
+       PPM[i]=(PPM[i]<=108)?0:(PPM[i]-108);
+     }	  
       if ((ppmWork.sbus.status & 0x08)==0) {
 #ifdef DEBUG_DUMP_PPM
         ppmDump = 1;


### PR DESCRIPTION
@kh4 
I figured I'd offer this patch up for consideration (possibly for a dev branch?). 

CSV link-state debugging feature.
Requires adding a jumper to output pins 1&2 in order to enable.
Runs at 19200 baud per your recommendation (hope this is also OK for longer timestamps, such as  for long-range, possibly 1hour+ flights?).

Due to jumper pin conflicts, this obviously makes it impossible to run in either 'scanner mode' or 'forced re-bind' modes simultaneously when running in 'csv debug' mode. However, I figured that it would simplify things to use pins 1&2, and it shouldn't really be an issue anyway (scannerMode is irrelevant & RX can be bound prior to enabling csv debugging). 

output format:
"@ timestamp:channel:signalRSSI:noiseRSSI:state"

state:
0: packet OK
1: packet dropped
2: de-sync slow hop

FS is indicated by:
"!timestamp"

I tested & verfied that it works. Only issue I found is that measured RSSI value gets 'stuck' outputting last value during periods of failsafe/slow hopping. As no packets are being received during FS, 'lastRSSIvalue' isn't updated. It's not really an issue if you're only interested in evaluating the link state though, but can be fixed however you see fit.

HTH & feedback is welcome
(sorry if I screwed up the push, new to git)