### PR TITLE
SBUS RX output: Fix correct number of stop bits for SBUS output

### DIFF
--- a/RX.h
+++ b/RX.h
@@ -687,8 +687,7 @@ void setup()
       (rx_config.pinMapping[TXD_OUTPUT] == PINMAP_SUMD)) {
     Serial.begin(115200);
   } else if (rx_config.pinMapping[TXD_OUTPUT] == PINMAP_SBUS) {
-    Serial.begin(100000);
-    UCSR0C |= 1<<UPM01; // set even parity
+    Serial.begin(100000, SERIAL_8E2); // Even parity, two stop bits
   } else if ((bind_data.flags & TELEMETRY_MASK) == TELEMETRY_FRSKY) {
     Serial.begin(9600);
   } else {


### PR DESCRIPTION
Could not get DJI A2 to accept SBUS output from Broversity RX receiver. Turned out it was only using 1 stop bit instead of 2 as it should. This solved the problem.