### PR TITLE
make 'slave mode' feature optional in build

### DIFF
--- a/openLRSng.ino
+++ b/openLRSng.ino
@@ -67,6 +67,7 @@
 //### Enabled Features (some features can be enabled / disabled with compile flag)
 #define CLI // Command-line interface
 #define CONFIGURATOR // Phoenix Serial Protocol (required for Configurator to work)
+//#define ENABLE_SLAVE_MODE // enable/disables i2c slave mode (saves ~1.5K)
 
 //### DEBUG flags, may be dangerous
 //#define TEST_NO_ACK_BY_CH1 // disable sending of acks from RX by channel 1


### PR DESCRIPTION
added conditional compilation statements to optionally disable slave mode feature if it's not needed (saves around 1.5K space). The i2c/slave settings in bind data are simply ignored on RX if slave mode is disabled in build.

I moved some stuff around in RX.h in order to keep slave code together, but everything is basically the same.

Compiled & tested; works fine. 