### PR TITLE
add TX module configuration baud rate setting

### DIFF
--- a/TX.h
+++ b/TX.h
@@ -218,7 +218,7 @@ inline int consoleRead()
   return result;
 }
 
-inline size_t consolePrint(const char str[])
+inline size_t consolePrint(const char* str)
 {
   size_t result = 0;
 #ifdef USE_CONSOLE_SERIAL
@@ -584,18 +584,18 @@ void setup(void)
 #endif
   buzzerInit();
 
-#ifdef __AVR_ATmega32U4__
-  Serial.begin(0); // Suppress warning on overflow on Leonardo
-#else
-  Serial.begin(115200);
-#endif
-
   setupRfmInterrupt();
 
   sei();
 
   setupProfile();
   txReadEeprom();
+
+#ifdef __AVR_ATmega32U4__
+  Serial.begin(0); // Suppress warning on overflow on Leonardo
+#else
+  Serial.begin(tx_config.console_baud_rate);
+#endif
 
   buzzerOn(BZ_FREQ);
   digitalWrite(BTN, HIGH);

--- a/binding.h
+++ b/binding.h
@@ -119,6 +119,7 @@ uint8_t defaultProfile = 0;
 struct tx_config {
   uint8_t  rfm_type;
   uint32_t max_frequency;
+  uint32_t console_baud_rate;
   uint32_t flags;
   uint8_t  chmap[16];
 } tx_config;
@@ -354,6 +355,7 @@ void setDefaultProfile(uint8_t profile)
 void txInitDefaults()
 {
   tx_config.max_frequency = MAX_RFM_FREQUENCY;
+  tx_config.console_baud_rate = DEFAULT_BAUDRATE;
   tx_config.flags = 0x00;
   TX_CONFIG_SETMINCH(5); // 6ch
   for (uint8_t i = 0; i < 16; i++) {

--- a/dialog.h
+++ b/dialog.h
@@ -74,6 +74,9 @@ void bindPrint(void)
   Serial.print(F("B) Micro (half) PPM    :"));
   printYesNo(tx_config.flags & MICROPPM);
 
+  Serial.print(F("C) TX console baudrate:"));
+  Serial.println(tx_config.console_baud_rate);
+  
   Serial.print(F("Calculated packet interval: "));
   Serial.print(getInterval(&bind_data));
   Serial.print(F(" == "));
@@ -165,6 +168,7 @@ void CLI_menu_headers(void)
     printVersion(version);
     Serial.println(F(" - System configuration"));
     Serial.println(F("Use numbers [0-9] to edit parameters"));
+    Serial.println(F("[C] set TX configuration serial baudrate"));
     Serial.println(F("[S] save settings to EEPROM and exit menu"));
     Serial.println(F("[X] revert changes and exit menu"));
     Serial.println(F("[I] reinitialize settings to sketch defaults"));
@@ -199,6 +203,9 @@ void CLI_menu_headers(void)
     break;
   case 9:
     Serial.println(F("Set serial baudrate: "));
+    break;
+  case 10:
+    Serial.println(F("Set TX config serial baudrate: "));
     break;
   }
 
@@ -703,6 +710,10 @@ void handleCLImenu(char c)
       tx_config.flags ^= MICROPPM;
       CLI_menu = -1;
       break;
+    case 'c':
+    case 'C':
+      CLI_menu = 10;
+      break;
     case 'z':
     case 'Z':
       CLI_RX_config();
@@ -775,6 +786,12 @@ void handleCLImenu(char c)
         case 9:
           if ((value >0) && (value <= 115200)) {
             bind_data.serial_baudrate = value;
+            valid_input = 1;
+          }
+          break;
+        case 10:
+          if ((value >0) && (value <= 115200)) {
+            tx_config.console_baud_rate = value;
             valid_input = 1;
           }
           break;


### PR DESCRIPTION
this adds an additional baudrate setting to the tx_config, allowing for
connecting to the CLI/Configurator with a user-selected baudrate
(instead of hard-coded 115200 baud)

This resolves issue #141 
FYI, this breaks Configurator, so it must go along with a related update/PR to Configurator (coming soon).