### PR TITLE
Extend PMR446 channel range to 16 channels

### DIFF
--- a/binding.h
+++ b/binding.h
@@ -68,7 +68,7 @@ typedef enum {
 #define MULTI_OPERATION_TIMEOUT_MS 5000
 
 // helper macro for European PMR channels
-#define EU_PMR_CH(x) (445993750L + 12500L * (x)) // valid for ch1-ch8
+#define EU_PMR_CH(x) (445993750L + 12500L * (x)) // valid for ch1-ch16 (Jan 2016  ECC update)
 
 // helper macro for US FRS channels 1-7
 #define US_FRS_CH(x) (462537500L + 25000L * (x)) // valid for ch1-ch7

--- a/dialog.h
+++ b/dialog.h
@@ -531,7 +531,7 @@ void handleRXmenu(char c)
         case 23:
           if ((CLI_buffer[0] | 0x20) == 'p') {
             value = strtoul(CLI_buffer + 1, NULL, 0);
-            if ((value >= 1) && (value <= 8)) {
+            if ((value >= 1) && (value <= 16)) {
               value=EU_PMR_CH(value);
             } else {
               value = 1; //invalid


### PR DESCRIPTION
Per ECC Decision (15)05, effective January 2016, PMR446 channel range
was extended from 8 to 16 channels for analog operation. This fix
reflects that change. This also references/partially fixes #105.

side-note, this will also require a small fix to configurator as well...