### PR TITLE
add support for inverted PPM output

### DIFF
--- a/RX.h
+++ b/RX.h
@@ -287,10 +287,17 @@ void setupOutputs()
 
   if (rx_config.pinMapping[PPM_OUTPUT] == PINMAP_PPM) {
     digitalWrite(OUTPUT_PIN[PPM_OUTPUT], HIGH);
+
 #ifdef USE_OCR1B
     TCCR1A = (1 << WGM11) | (1 << COM1B1);
+	if(rx_config.flags & INVERTED_PPMOUT) {
+		TCCR1A |= (1 << COM1B0);
+	}
 #else
     TCCR1A = (1 << WGM11) | (1 << COM1A1);
+	if(rx_config.flags & INVERTED_PPMOUT) {
+		TCCR1A |= (1 << COM1A0);
+	}
 #endif
   } else {
     TCCR1A = (1 << WGM11);

--- a/binding.h
+++ b/binding.h
@@ -38,6 +38,7 @@
 #define SLAVE_MODE          0x04
 #define IMMEDIATE_OUTPUT    0x08
 #define STATIC_BEACON       0x10
+#define INVERTED_PPMOUT      0x40
 #define WATCHDOG_USED       0x80 // read only flag, only sent to configurator
 
 // BIND_DATA flag masks

--- a/dialog.h
+++ b/dialog.h
@@ -154,6 +154,8 @@ void rxPrint(void)
   printYesNo(rx_config.flags & SLAVE_MODE);
   Serial.print(F("Q) Output before link (=FS) : "));
   printYesNo(rx_config.flags & IMMEDIATE_OUTPUT);
+  Serial.print(F("T) Inverted PPM output: "));
+  printYesNo(rx_config.flags & INVERTED_PPMOUT);
 }
 
 void CLI_menu_headers(void)
@@ -461,6 +463,13 @@ void handleRXmenu(char c)
     case 'Q':
       Serial.println(F("Toggled 'immediate output'"));
       rx_config.flags ^= IMMEDIATE_OUTPUT;
+      CLI_menu = -1;
+      RX_menu_headers();
+      break;
+    case 't':
+    case 'T':
+      Serial.println(F("Toggled 'inverted PPM output'"));
+      rx_config.flags ^= INVERTED_PPMOUT;
       CLI_menu = -1;
       RX_menu_headers();
       break;


### PR DESCRIPTION
Adds flags & logic for inverted PPM output on RX. Tested & confirmed that PPM signal is inverted (via o-scope). Can be set via CLI, but requires additional patch to Configurator.

This resolves issue #113