### PR TITLE
Major version upgrade to 4.0.0

### DIFF
--- a/src/version.h
+++ b/src/version.h
@@ -1,4 +1,4 @@
 // Version number in single uint16 [8bit major][4bit][4bit]
 // a.b.c == 0xaabc
-#define OPENLRSNG_VERSION 0x0390
+#define OPENLRSNG_VERSION 0x0400
 static uint16_t version = OPENLRSNG_VERSION;


### PR DESCRIPTION
@mikeller 
due to the recent changes in the TX & RX configurations, are we ready to upgrade to 4.0.0? 
(FYI, the PR for adding support configurator for the TX console baudrate checks for & requires version 4.0 to work)

If not, should we leave this PR pending until then?