### PR TITLE
fix start-up timing issue for 32u4

### DIFF
--- a/TX.h
+++ b/TX.h
@@ -553,6 +553,12 @@ inline bool newMultiProfileSelected(bool useTimeout)
 
 void setup(void)
 {
+#ifdef __AVR_ATmega32U4__
+// mimic standard bootloader start-up delay
+// necessary for Configurator connection stability
+  delay(850);  
+#endif
+
   watchdogConfig(WATCHDOG_OFF);
 
   setupSPI();


### PR DESCRIPTION
add a start-up delay to mimic standard bootloader in order to allow
Configurator time to detect boot message