### PR TITLE
add support for binary proto on RX side.

### DIFF
--- a/openLRSng.ino
+++ b/openLRSng.ino
@@ -88,8 +88,11 @@
 #include "wd.h"
 #include "common.h"
 
-#if (COMPILE_TX == 1)
+#ifdef CONFIGURATOR
 #include "binary_com.h"
+#endif
+
+#if (COMPILE_TX == 1)
 #include "rxc.h"
 #ifdef CLI_ENABLED
 #include "dialog.h"


### PR DESCRIPTION
This adds a slimmed-down version of the Configurator binary protocol to the RX module for direct-connection to Configurator. 

Also, this removes the forced RX 'scanner mode' which is set by placing a jumper across output pins 2 and 3. This is no longer needed as you can simply directly connect the RX to Configurator via the binary protocol.

In order for this to work within Configurator, this requires patched serial back-end from PR openLRSng/openLRSng-configurator#45

FYI, remote connection to RX from TX via Configurator still works as before. This simply adds the ability to also direct-connect to the RX.