### PR TITLE
add hop channel check into packet header

### DIFF
--- a/openLRSng/common.h
+++ b/openLRSng/common.h
@@ -277,6 +277,8 @@ void check_module(void)
 
 void setHopChannel(uint8_t ch)
 {
+  uint8_t magicLSB = (bind_data.rf_magic & 0xFF) ^ ch;
+  rfmSetHeader(3, magicLSB);
   rfmSetChannel(bind_data.hopchannel[ch]);
 }
 


### PR DESCRIPTION
revert to original logic of adding xor'ed RF magic value into check
header based on current hop channel number.

fixes #203.