### PR TITLE
fix broken RX->TX serial bridge connection

### DIFF
--- a/openLRSng/TX.h
+++ b/openLRSng/TX.h
@@ -985,7 +985,8 @@ void loop(void)
     }
     linkQuality |= 1;
 
-  rfmGetPacket(rx_buf, TELEMETRY_PACKETSIZE);
+    rfmGetPacket(rx_buf, TELEMETRY_PACKETSIZE);
+    rx_reset();
 
     if ((tx_buf[0] ^ rx_buf[0]) & 0x40) {
       tx_buf[0] ^= 0x40; // swap sequence to ack


### PR DESCRIPTION
- Add missing rx_reset() call to fix broken telemetry packet handling on TX side. 
- Without rx_reset() call, the received packet handler routine will incorrectly run on each loop iteration, which breaks the incoming serial packet handling.
- this resolves #206 