### PR TITLE
fix telemetry packet interval offset

### DIFF
--- a/openLRSng/common.h
+++ b/openLRSng/common.h
@@ -72,7 +72,7 @@ uint32_t getInterval(struct bind_data *bd)
   ret = (BYTES_AT_BAUD_TO_USEC(getPacketSize(bd), modem_params[bd->modem_params].bps, bd->flags&DIVERSITY_ENABLED) + 2000);
 
   if (bd->flags & TELEMETRY_MASK) {
-    ret += (BYTES_AT_BAUD_TO_USEC(TELEMETRY_PACKETSIZE, modem_params[bd->modem_params].bps, bd->flags&DIVERSITY_ENABLED) + 2000);
+    ret += (BYTES_AT_BAUD_TO_USEC(TELEMETRY_PACKETSIZE, modem_params[bd->modem_params].bps, bd->flags&DIVERSITY_ENABLED) + 1000);
   }
 
   // round up to ms


### PR DESCRIPTION
for some unknown reason that I can't recall, I mistakenly changed the offset value for telemetry packets from 2000 to 1000. This reverts the offset to the original value & thus fixes backward compatibility with previous firmware versions

This relates to the interop issue mentioned in #205 