### PR TITLE
Update outdated PIO platform parameters

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -48,7 +48,7 @@ platform    = atmelavr
 framework   = arduino
 board       = pro16MHzatmega328
 build_flags = ${common.build_flags}
-board_f_cpu = 16000000L
+board_build.f_cpu = 16000000L
 lib_deps    = ${common.lib_deps}
 src_filter  = ${common.default_src_filter}
 
@@ -62,7 +62,7 @@ platform    = atmelavr
 framework   = arduino
 board       = pro16MHzatmega328
 build_flags = ${common.build_flags}
-board_f_cpu = 16000000L
+board_build.f_cpu = 16000000L
 lib_deps    = ${common.lib_deps}
 src_filter  = ${common.default_src_filter}
 
@@ -76,7 +76,7 @@ platform    = atmelavr
 framework   = arduino
 board       = pro16MHzatmega328
 build_flags = ${common.build_flags}
-board_f_cpu = 16000000L
+board_build.f_cpu = 16000000L
 lib_deps    = ${common.lib_deps}
 src_filter  = ${common.default_src_filter}
 
@@ -90,7 +90,7 @@ platform    = atmelavr
 framework   = arduino
 board       = pro16MHzatmega328
 build_flags = ${common.build_flags}
-board_f_cpu = 16000000L
+board_build.f_cpu = 16000000L
 lib_deps    = ${common.lib_deps}
 src_filter  = ${common.default_src_filter}
 
@@ -104,7 +104,7 @@ platform    = atmelavr
 framework   = arduino
 board       = pro16MHzatmega328
 build_flags = ${common.build_flags}
-board_f_cpu = 16000000L
+board_build.f_cpu = 16000000L
 lib_deps    = ${common.lib_deps}
 src_filter  = ${common.default_src_filter}
 
@@ -118,7 +118,7 @@ platform    = atmelavr
 framework   = arduino
 board       = pro16MHzatmega328
 build_flags = ${common.build_flags}
-board_f_cpu = 16000000L
+board_build.f_cpu = 16000000L
 lib_deps    = ${common.lib_deps}
 src_filter  = ${common.default_src_filter}
 
@@ -132,7 +132,7 @@ platform    = atmelavr
 framework   = arduino
 board       = leonardo
 build_flags = ${common.build_flags}
-board_f_cpu = 16000000L
+board_build.f_cpu = 16000000L
 lib_deps    = ${common.lib_deps}
 src_filter  = ${common.default_src_filter}
 
@@ -146,7 +146,7 @@ platform    = atmelavr
 framework   = arduino
 board       = pro16MHzatmega328
 build_flags = ${common.build_flags}
-board_f_cpu = 16000000L
+board_build.f_cpu = 16000000L
 lib_deps    = ${common.lib_deps}
 src_filter  = ${common.default_src_filter}
 
@@ -160,7 +160,7 @@ platform    = atmelavr
 framework   = arduino
 board       = pro16MHzatmega328
 build_flags = ${common.build_flags}
-board_f_cpu = 16000000L
+board_build.f_cpu = 16000000L
 lib_deps    = ${common.lib_deps}
 src_filter  = ${common.default_src_filter}
 
@@ -174,6 +174,6 @@ platform    = atmelavr
 framework   = arduino
 board       = pro16MHzatmega328
 build_flags = ${common.build_flags}
-board_f_cpu = 16000000L
+board_build.f_cpu = 16000000L
 lib_deps    = ${common.lib_deps}
 src_filter  = ${common.default_src_filter}


### PR DESCRIPTION
`board_f_cpu` option is deprecated and will be replaced with `board_build.f_cpu` in next PIO release.